### PR TITLE
composer: fix autoload-dev for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "league\\CommonMark\\Ext\\InlinesOnly\\Test\\": "tests"
+            "League\\CommonMark\\Ext\\InlinesOnly\\Tests\\": "tests"
         }
     },
     "scripts": {


### PR DESCRIPTION
looks like this problem has spewed over multiple repositories.

refs:
- https://github.com/thephpleague/commonmark-ext-smartpunct/pull/1