### PR TITLE
Deprecate extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes will be documented in this file.
 
 ## [Unreleased][unreleased]
 
+## [1.1.0] - 2020-04-04
+
+### Deprecated
+
+**This extension has been deprecated**.  All of its functionality now exists in league/commonmark 1.3+ under the `League\CommonMark\Extension\InlinesOnly` namespace.
+
+
 ## [1.0.0] - 2019-06-29
 
 No code changes have been introduced since 1.0.0-beta1.
@@ -24,7 +31,8 @@ No code changes have been introduced since 1.0.0-beta1.
 
 Initial release!
 
-[unreleased]: https://github.com/thephpleague/commonmark-ext-inlines-only/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/thephpleague/commonmark-ext-inlines-only/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/thephpleague/commonmark-ext-inlines-only/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/thephpleague/commonmark-ext-inlines-only/compare/v1.0.0-beta1...v1.0.0
 [1.0.0-beta1]: https://github.com/thephpleague/commonmark-ext-inlines-only/compare/v0.2.0...v1.0.0-beta1
 [0.2.0]: https://github.com/thephpleague/commonmark-ext-inlines-only/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]
 
+## DEPRECATED
+
+**This extension has been deprecated**.  All of its functionality now exists in [`league/commonmark`][link-league-commonmark] 1.3+ under the `League\CommonMark\Extension\InlinesOnly` namespace, so you should upgrade to that version and use that bundled extension instead of this one.
+
+## Overview
+
 This extension configures the [`league/commonmark` Markdown parser for PHP](https://github.com/thephpleague/commonmark) to only render inline elements - no paragraph tags, headers, code blocks, etc.
 
 ## Install

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php" : "^7.1",
-        "league/commonmark": "^1.0"
+        "league/commonmark": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"
@@ -35,7 +35,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
-    }
+    },
+    "abandoned": "league/commonmark"
 }

--- a/src/ChildRenderer.php
+++ b/src/ChildRenderer.php
@@ -15,33 +15,30 @@
 namespace League\CommonMark\Ext\InlinesOnly;
 
 use League\CommonMark\Block\Element\AbstractBlock;
-use League\CommonMark\Block\Element\Document;
-use League\CommonMark\Block\Element\InlineContainerInterface;
 use League\CommonMark\Block\Renderer\BlockRendererInterface;
 use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\InlinesOnly\ChildRenderer as CoreRenderer;
 
 /**
  * Simply renders child elements as-is, adding newlines as needed.
+ *
+ * @deprecated The league/commonmark-ext-inlines-only extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
  */
 final class ChildRenderer implements BlockRendererInterface
 {
+    private $coreRenderer;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-autolink is deprecated; use %s from league/commonmark 1.3+ instead', CoreRenderer::class), E_USER_DEPRECATED);
+        $this->coreRenderer = new CoreRenderer();
+    }
+
     /**
      * {@inheritdoc}
      */
     public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false)
     {
-        $out = '';
-
-        if ($block instanceof InlineContainerInterface) {
-            $out .= $htmlRenderer->renderInlines($block->children());
-        } else {
-            $out .= $htmlRenderer->renderBlocks($block->children());
-        }
-
-        if (!($block instanceof Document)) {
-            $out .= "\n";
-        }
-
-        return $out;
+        return $this->coreRenderer->render($block, $htmlRenderer, $inTightList);
     }
 }

--- a/src/InlinesOnlyExtension.php
+++ b/src/InlinesOnlyExtension.php
@@ -14,53 +14,25 @@
 
 namespace League\CommonMark\Ext\InlinesOnly;
 
-use League\CommonMark\Block\Element\Document;
-use League\CommonMark\Block\Element\Paragraph;
-use League\CommonMark\Block\Parser as BlockParser;
 use League\CommonMark\ConfigurableEnvironmentInterface;
-use League\CommonMark\Delimiter\Processor\EmphasisDelimiterProcessor;
 use League\CommonMark\Extension\ExtensionInterface;
-use League\CommonMark\Inline\Element as InlineElement;
-use League\CommonMark\Inline\Parser as InlineParser;
-use League\CommonMark\Inline\Renderer as InlineRenderer;
+use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension as CoreExtension;
 
+/**
+ * @deprecated The league/commonmark-ext-inlines-only extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class InlinesOnlyExtension implements ExtensionInterface
 {
+    private $coreExtension;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-inlines-only is deprecated; use %s from league/commonmark 1.3+ instead', CoreExtension::class), E_USER_DEPRECATED);
+        $this->coreExtension = new CoreExtension();
+    }
+
     public function register(ConfigurableEnvironmentInterface $environment)
     {
-        $childRenderer = new ChildRenderer();
-
-        $environment
-            ->addBlockParser(new BlockParser\LazyParagraphParser(), -200)
-
-            ->addInlineParser(new InlineParser\NewlineParser(),     200)
-            ->addInlineParser(new InlineParser\BacktickParser(),    150)
-            ->addInlineParser(new InlineParser\EscapableParser(),    80)
-            ->addInlineParser(new InlineParser\EntityParser(),       70)
-            ->addInlineParser(new InlineParser\AutolinkParser(),     50)
-            ->addInlineParser(new InlineParser\HtmlInlineParser(),   40)
-            ->addInlineParser(new InlineParser\CloseBracketParser(), 30)
-            ->addInlineParser(new InlineParser\OpenBracketParser(),  20)
-            ->addInlineParser(new InlineParser\BangParser(),         10)
-
-            ->addBlockRenderer(Document::class, $childRenderer, 0)
-            ->addBlockRenderer(Paragraph::class, $childRenderer, 0)
-
-            ->addInlineRenderer(InlineElement\Code::class,       new InlineRenderer\CodeRenderer(),       0)
-            ->addInlineRenderer(InlineElement\Emphasis::class,   new InlineRenderer\EmphasisRenderer(),   0)
-            ->addInlineRenderer(InlineElement\HtmlInline::class, new InlineRenderer\HtmlInlineRenderer(), 0)
-            ->addInlineRenderer(InlineElement\Image::class,      new InlineRenderer\ImageRenderer(),      0)
-            ->addInlineRenderer(InlineElement\Link::class,       new InlineRenderer\LinkRenderer(),       0)
-            ->addInlineRenderer(InlineElement\Newline::class,    new InlineRenderer\NewlineRenderer(),    0)
-            ->addInlineRenderer(InlineElement\Strong::class,     new InlineRenderer\StrongRenderer(),     0)
-            ->addInlineRenderer(InlineElement\Text::class,       new InlineRenderer\TextRenderer(),       0)
-        ;
-
-        if ($environment->getConfig('use_asterisk', true)) {
-            $environment->addDelimiterProcessor(new EmphasisDelimiterProcessor('*'));
-        }
-        if ($environment->getConfig('use_underscore', true)) {
-            $environment->addDelimiterProcessor(new EmphasisDelimiterProcessor('_'));
-        }
+        $this->coreExtension->register($environment);
     }
 }


### PR DESCRIPTION
The league/commonmark-ext-inlines-only extension is being deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.